### PR TITLE
Licenses

### DIFF
--- a/APDU/APDU.h
+++ b/APDU/APDU.h
@@ -3,7 +3,6 @@
 //  APDU
 //
 //  Created by Benjamin P Toews on 2/7/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 #import <Cocoa/Cocoa.h>
@@ -15,5 +14,3 @@ FOUNDATION_EXPORT double APDUVersionNumber;
 FOUNDATION_EXPORT const unsigned char APDUVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <APDU/PublicHeader.h>
-
-

--- a/APDU/AuthenticationRequest.swift
+++ b/APDU/AuthenticationRequest.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/14/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/APDU/AuthenticationResponse.swift
+++ b/APDU/AuthenticationResponse.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/14/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -11,7 +10,7 @@ import Foundation
 public struct AuthenticationResponse: RawConvertible {
     let body: Data
     let trailer: ResponseStatus
-    
+
     public var userPresence: UInt8 {
         return body[0]
     }
@@ -20,7 +19,7 @@ public struct AuthenticationResponse: RawConvertible {
         let lowerBound = MemoryLayout<UInt8>.size
         let upperBound = lowerBound + MemoryLayout<UInt32>.size
         let data = body.subdata(in: lowerBound..<upperBound)
-        
+
         return data.withUnsafeBytes { (ptr: UnsafePointer<UInt32>) -> UInt32 in
             return ptr.pointee.bigEndian
         }
@@ -37,7 +36,7 @@ public struct AuthenticationResponse: RawConvertible {
         writer.write(userPresence)
         writer.write(counter)
         writer.writeData(signature)
-        
+
         body = writer.buffer
         trailer = .NoError
     }
@@ -48,13 +47,13 @@ extension AuthenticationResponse: Response {
         self.body = body
         self.trailer = trailer
     }
-    
+
     func validateBody() throws {
         // TODO: minimum signature size?
         if body.count < MemoryLayout<UInt8>.size + MemoryLayout<UInt32>.size + 1 {
             throw ResponseError.BadSize
         }
-        
+
         if trailer != .NoError {
             throw ResponseError.BadStatus
         }

--- a/APDU/Command.swift
+++ b/APDU/Command.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/7/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -18,9 +17,9 @@ public protocol Command {
     var header: CommandHeader { get }
     var body: Data { get }
     var trailer: CommandTrailer { get }
-    
+
     init(header: CommandHeader, body: Data, trailer: CommandTrailer)
-    
+
     func validateBody() throws
 }
 
@@ -31,16 +30,16 @@ extension Command {
         writer.writeData(header.raw)
         writer.writeData(body)
         writer.writeData(trailer.raw)
-        
+
         return writer.buffer
     }
-    
+
     public init(raw: Data) throws {
         let reader = DataReader(data: raw)
         let header: CommandHeader
         let body: Data
         let trailer: CommandTrailer
-        
+
         do {
             header = try CommandHeader(reader: reader)
             body = try reader.readData(header.dataLength)
@@ -48,7 +47,7 @@ extension Command {
         } catch DataReaderError.End {
             throw ResponseStatus.WrongLength
         }
-        
+
         self.init(header: header, body: body, trailer: trailer)
 
         try validateBody()

--- a/APDU/CommandHeader.swift
+++ b/APDU/CommandHeader.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/11/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -64,7 +63,7 @@ public struct CommandHeader: RawConvertible, MessagePart {
             throw ResponseStatus.WrongLength
         }
     }
-    
+
     init(cla: CommandClass = .Reserved, ins: CommandCode, p1: UInt8 = 0x00, p2: UInt8 = 0x00, dataLength: Int) {
         self.cla = cla
         self.ins = ins

--- a/APDU/CommandTrailer.swift
+++ b/APDU/CommandTrailer.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/25/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -54,7 +53,7 @@ public struct CommandTrailer: RawConvertible, MessagePart {
             throw ResponseStatus.WrongLength
         }
     }
-    
+
     init(noBody: Bool, maxResponse: Int = MaxResponseSize) {
         self.noBody = noBody
         self.maxResponse = maxResponse

--- a/APDU/Constants.swift
+++ b/APDU/Constants.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/7/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -31,7 +30,7 @@ public enum CommandCode: UInt8 {
 public enum Control: UInt8 {
     case EnforceUserPresenceAndSign = 0x03
     case CheckOnly = 0x07
-    
+
     // Used internally.
     case Invalid = 0xFF
 }
@@ -39,7 +38,7 @@ public enum Control: UInt8 {
 // ISO7816-4
 public enum ResponseStatus: UInt16, EndianEnumProtocol, Error {
     public typealias RawValue = UInt16
-    
+
     case NoError = 0x9000
     case WrongData = 0x6A80
     case ConditionsNotSatisfied = 0x6985

--- a/APDU/Data/DataReader.swift
+++ b/APDU/Data/DataReader.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/11/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/APDU/Data/DataWriter.swift
+++ b/APDU/Data/DataWriter.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/12/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/APDU/Data/Endian.swift
+++ b/APDU/Data/Endian.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/12/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/APDU/ErrorResponse.swift
+++ b/APDU/ErrorResponse.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/26/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -23,7 +22,7 @@ extension ErrorResponse: Response {
         self.body = body
         self.trailer = trailer
     }
-    
+
     func validateBody() throws {
         if body.count != 0 {
             throw ResponseError.BadSize

--- a/APDU/MessagePart.swift
+++ b/APDU/MessagePart.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/7/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/APDU/RawConvertible.swift
+++ b/APDU/RawConvertible.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/7/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/APDU/RegisterRequest.swift
+++ b/APDU/RegisterRequest.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/10/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -12,7 +11,7 @@ public struct RegisterRequest: RawConvertible {
     public let header: CommandHeader
     public let body: Data
     public let trailer: CommandTrailer
-    
+
     public var challengeParameter: Data {
         let lowerBound = 0
         let upperBound = lowerBound + U2F_CHAL_SIZE
@@ -29,7 +28,7 @@ public struct RegisterRequest: RawConvertible {
         let writer = DataWriter()
         writer.writeData(challengeParameter)
         writer.writeData(applicationParameter)
-        
+
         self.body = writer.buffer
         self.header = CommandHeader(ins: .Register, dataLength: body.count)
         self.trailer = CommandTrailer(noBody: false)
@@ -42,7 +41,7 @@ extension RegisterRequest: Command {
         self.body = body
         self.trailer = trailer
     }
-    
+
     public func validateBody() throws {
         if body.count != U2F_CHAL_SIZE + U2F_APPID_SIZE {
             throw ResponseStatus.WrongLength

--- a/APDU/RegisterResponse.swift
+++ b/APDU/RegisterResponse.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/11/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -16,11 +15,11 @@ public struct RegisterResponse: RawConvertible {
     var reserved: UInt8 {
         return body.subdata(in: reservedRange)[0]
     }
-    
+
     public var publicKey: Data {
         return body.subdata(in: publicKeyRange)
     }
-    
+
     var keyHandleLength: Int {
         return Int(body.subdata(in: keyHandleLengthRange)[0])
     }
@@ -28,7 +27,7 @@ public struct RegisterResponse: RawConvertible {
     public var keyHandle: Data {
         return body.subdata(in: keyHandleRange)
     }
-    
+
     public var certificate: Data {
         return body.subdata(in: certificateRange)
     }
@@ -42,13 +41,13 @@ public struct RegisterResponse: RawConvertible {
         let upperBound = MemoryLayout<UInt8>.size
         return lowerBound..<upperBound
     }
-    
+
     var publicKeyRange: Range<Int> {
         let lowerBound = reservedRange.upperBound
         let upperBound = lowerBound + U2F_EC_POINT_SIZE
         return lowerBound..<upperBound
     }
-    
+
     var keyHandleLengthRange: Range<Int> {
         let lowerBound = publicKeyRange.upperBound
         let upperBound = lowerBound + MemoryLayout<UInt8>.size
@@ -60,7 +59,7 @@ public struct RegisterResponse: RawConvertible {
         let upperBound = lowerBound + keyHandleLength
         return lowerBound..<upperBound
     }
-    
+
     var certificateSize: Int {
         let remainingRange: Range<Int> = keyHandleRange.upperBound..<body.count
         let remaining = body.subdata(in: remainingRange)
@@ -72,19 +71,19 @@ public struct RegisterResponse: RawConvertible {
             return 0
         }
     }
-    
+
     var certificateRange: Range<Int> {
         let lowerBound = keyHandleRange.upperBound
         let upperBound = lowerBound + certificateSize
         return lowerBound..<upperBound
     }
-    
+
     var signatureRange: Range<Int> {
         let lowerBound = certificateRange.upperBound
         let upperBound = body.count
         return lowerBound..<upperBound
     }
-    
+
     public init(publicKey: Data, keyHandle: Data, certificate: Data, signature: Data) {
         let writer = DataWriter()
         writer.write(UInt8(0x05)) // reserved
@@ -104,7 +103,7 @@ extension RegisterResponse: Response {
         self.body = body
         self.trailer = trailer
     }
-    
+
     func validateBody() throws {
         // Check that we at least have key-handle length.
         var min = MemoryLayout<UInt8>.size + U2F_EC_POINT_SIZE + MemoryLayout<UInt8>.size
@@ -118,12 +117,12 @@ extension RegisterResponse: Response {
         if body.count < min {
             throw ResponseError.BadSize
         }
-        
+
         // Check that cert is parsable.
         if certificateSize == 0 {
             throw ResponseError.BadCertificate
         }
-        
+
         // Check that we at least have one byte of signature.
         // TODO: minimum signature size?
         min += certificateSize + 1
@@ -134,7 +133,7 @@ extension RegisterResponse: Response {
         if reserved != 0x05 {
             throw ResponseError.BadData
         }
-        
+
         if trailer != .NoError {
             throw ResponseError.BadStatus
         }

--- a/APDU/Response.swift
+++ b/APDU/Response.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/7/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -18,9 +17,9 @@ enum ResponseError: Error {
 protocol Response {
     var body: Data { get }
     var trailer: ResponseStatus { get }
-    
+
     init(body: Data, trailer: ResponseStatus)
-    
+
     func validateBody() throws
 }
 
@@ -30,10 +29,10 @@ extension Response {
         let writer = DataWriter()
         writer.writeData(body)
         writer.write(trailer)
-        
+
         return writer.buffer
     }
-    
+
     public init(raw: Data) throws {
         let reader = DataReader(data: raw)
         let body = try reader.readData(reader.remaining - 2)
@@ -43,7 +42,7 @@ extension Response {
 
         try validateBody()
     }
-    
+
     // For testing with libu2f-host
     public init(raw: Data, bodyOnly: Bool) throws {
         if bodyOnly {

--- a/APDU/VersionRequest.swift
+++ b/APDU/VersionRequest.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/25/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -12,7 +11,7 @@ public struct VersionRequest: RawConvertible {
     public let header: CommandHeader
     public let body: Data
     public let trailer: CommandTrailer
-    
+
     init() {
         self.header = CommandHeader(ins: .Version, dataLength: 0)
         self.body = Data()
@@ -26,7 +25,7 @@ extension VersionRequest: Command {
         self.body = body
         self.trailer = trailer
     }
-    
+
     public func validateBody() throws {
         if body.count > 0 {
             throw ResponseStatus.WrongLength

--- a/APDU/VersionResponse.swift
+++ b/APDU/VersionResponse.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/25/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -11,7 +10,7 @@ import Foundation
 public struct VersionResponse: RawConvertible {
     let body: Data
     let trailer: ResponseStatus
-    
+
     public var version: String {
         return String(data: body, encoding: .utf8) ?? ""
     }
@@ -27,12 +26,12 @@ extension VersionResponse: Response {
         self.body = body
         self.trailer = trailer
     }
-    
+
     func validateBody() throws {
         if version.lengthOfBytes(using: .utf8) < 1 {
             throw ResponseError.BadSize
         }
-        
+
         if trailer != .NoError {
             throw ResponseError.BadStatus
         }

--- a/APDUTests/AuthenticationRequestTests.swift
+++ b/APDUTests/AuthenticationRequestTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/6/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 import XCTest
 
@@ -11,7 +10,7 @@ class AuthenticationRequestTests: XCTestCase {
     func testChromeRequest() throws {
         let r = Data(base64Encoded: "AAIDAAAAgeOwxEKY/BwUmvv0yJlvuSQnrkHkZJuTTKSVmRt4UrhVcGF9/tBlhjr0fBVVbJF5iICCjMQH/fcK6FARVpRloHVAIA5xiih5UyR97Gx8DMpSZgno9djTV85XM+VQfZNgADuFrTX978Gq3C8F6BfBLgD042ioARsymZUhkDxd3i3nsQAA")!
         let c = try AuthenticationRequest(raw: r)
-        
+
         XCTAssertEqual(c.header.cla, CommandClass.Reserved)
         XCTAssertEqual(c.header.ins, CommandCode.Authenticate)
         XCTAssertEqual(c.header.p1, Control.EnforceUserPresenceAndSign.rawValue)
@@ -19,13 +18,13 @@ class AuthenticationRequestTests: XCTestCase {
         XCTAssertEqual(c.trailer.maxResponse, MaxResponseSize)
         XCTAssertEqual(c.raw, r)
     }
-    
+
     func testRequest() throws {
         let c = Data(repeating: 0xAA, count: 32)
         let a = Data(repeating: 0xBB, count: 32)
         let k = Data(repeating: 0xCC, count: 16)
         let cmd = AuthenticationRequest(challengeParameter: c, applicationParameter: a, keyHandle: k, control: .CheckOnly)
-        
+
         XCTAssertEqual(cmd.header.cla, CommandClass.Reserved)
         XCTAssertEqual(cmd.header.ins, CommandCode.Authenticate)
         XCTAssertEqual(cmd.control, Control.CheckOnly)
@@ -49,7 +48,7 @@ class AuthenticationRequestTests: XCTestCase {
             0x00,
             0x00
         ]))
-        
+
         let cmd2 = try AuthenticationRequest(raw: cmd.raw)
         XCTAssertEqual(cmd.header.cla, cmd2.header.cla)
         XCTAssertEqual(cmd.header.ins, cmd2.header.ins)

--- a/APDUTests/CommandHeaderTests.swift
+++ b/APDUTests/CommandHeaderTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/11/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/APDUTests/CommandTrailerTests.swift
+++ b/APDUTests/CommandTrailerTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/25/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/APDUTests/DataTests/DataReaderTests.swift
+++ b/APDUTests/DataTests/DataReaderTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/11/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/APDUTests/DataTests/DataWriterTests.swift
+++ b/APDUTests/DataTests/DataWriterTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/12/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/APDUTests/RegisterRequestTests.swift
+++ b/APDUTests/RegisterRequestTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/6/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest
@@ -13,7 +12,7 @@ class RegisterRequestTests: XCTestCase {
     func testChromeRequest() throws {
         let r = Data(base64Encoded: "AAEDAAAAQEr8hj61EL83BjxGaqSnMUyWyXeBIAhGhQ2zbkFcgOzbcGF9/tBlhjr0fBVVbJF5iICCjMQH/fcK6FARVpRloHUAAA==")!
         let c = try RegisterRequest(raw: r)
-        
+
         XCTAssertEqual(c.header.cla, CommandClass.Reserved)
         XCTAssertEqual(c.header.ins, CommandCode.Register)
         XCTAssertEqual(c.header.p1, Control.EnforceUserPresenceAndSign.rawValue)
@@ -21,7 +20,7 @@ class RegisterRequestTests: XCTestCase {
         XCTAssertEqual(c.trailer.maxResponse, MaxResponseSize)
         XCTAssertEqual(c.raw, r)
     }
-    
+
     func testRequest() throws {
         let c = Data(repeating: 0xAA, count: 32)
         let a = Data(repeating: 0xBB, count: 32)
@@ -47,7 +46,7 @@ class RegisterRequestTests: XCTestCase {
             0x00,
             0x00
         ]))
-        
+
         let cmd2 = try RegisterRequest(raw: cmd.raw)
         XCTAssertEqual(cmd.header.cla, cmd2.header.cla)
         XCTAssertEqual(cmd.header.ins, cmd2.header.ins)

--- a/APDUTests/ResponseTests.swift
+++ b/APDUTests/ResponseTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/12/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/APDUTests/TestUtil.swift
+++ b/APDUTests/TestUtil.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/10/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/APDUTests/VersionRequestTests.swift
+++ b/APDUTests/VersionRequestTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/6/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest
@@ -13,7 +12,7 @@ class VersionRequestTests: XCTestCase {
     func testChromeRequest() throws {
         let r = Data(base64Encoded: "AAMAAAAAAA==")!
         let c = try VersionRequest(raw: r)
-        
+
         XCTAssertEqual(c.header.cla, CommandClass.Reserved)
         XCTAssertEqual(c.header.ins, CommandCode.Version)
         XCTAssertEqual(c.header.p1, 0x00)
@@ -23,7 +22,7 @@ class VersionRequestTests: XCTestCase {
         XCTAssertEqual(c.trailer.maxResponse, MaxResponseSize)
         XCTAssertEqual(c.raw, r)
     }
-    
+
     func testRequest() {
         let c = VersionRequest()
 

--- a/README.md
+++ b/README.md
@@ -83,3 +83,8 @@ There are two parts to Soft U2F: the driver and the app. To use a modified versi
 ## Known app-IDs/facets
 
 Every website using U2F has an app-ID. For example, the app-ID of [Yubico's U2F demo page](https://demo.yubico.com/u2f) is `https://demo.yubico.com`. When the low-level U2F authenticator receives a request to register/authenticate a website, it doesn't receive the friendly app-ID string. Instead, it receives a SHA256 digest of the app-ID. To be able to show a helpful alert message when a website is trying to register/authenticate, a list of app-ID digests is maintained in this repository. You can find the list [here](https://github.com/github/SoftU2F/blob/master/SoftU2FTool/KnownFacets.swift). If your company's app-ID is missing from this list, open a pull request to add it.
+
+
+## License
+
+This project is MIT licensed, except for the files in [`/inc`](https://github.com/github/SoftU2F/tree/master/inc), which are included with their own licenses.

--- a/SelfSignedCertificate/SelfSignedCertificate.h
+++ b/SelfSignedCertificate/SelfSignedCertificate.h
@@ -3,7 +3,6 @@
 //  SelfSignedCertificate
 //
 //  Created by Benjamin P Toews on 2/7/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 #import <Cocoa/Cocoa.h>
@@ -15,5 +14,3 @@ FOUNDATION_EXPORT double SelfSignedCertificateVersionNumber;
 FOUNDATION_EXPORT const unsigned char SelfSignedCertificateVersionString[];
 
 #import "public.h"
-
-

--- a/SelfSignedCertificate/SelfSignedCertificate.m
+++ b/SelfSignedCertificate/SelfSignedCertificate.m
@@ -3,7 +3,6 @@
 //  SecurityKey
 //
 //  Created by Benjamin P Toews on 8/19/16.
-//  Copyright © 2017 GitHub, inc. All rights reserved.
 //
 
 #import "private.h"
@@ -53,7 +52,7 @@ const int cert_len = 281;
   unsigned char *buf;
   X509 *x509;
   const unsigned char *crt_cpy = cert;
-  
+
   x509 = d2i_X509(NULL, &crt_cpy, cert_len);
   if (x509 == NULL) {
     printf("failed to parse cert\n");
@@ -67,9 +66,9 @@ const int cert_len = 281;
     X509_free(x509);
     return nil;
   }
-  
+
   X509_free(x509);
-  
+
   return [[NSData alloc] initWithBytes:buf length:len];
 }
 
@@ -81,33 +80,33 @@ const int cert_len = 281;
   EC_KEY *ec;
   EVP_PKEY *pkey;
   const unsigned char *priv_cpy = priv;
-  
+
   ec = d2i_ECPrivateKey(NULL, &priv_cpy, priv_len);
   if (ec == NULL) {
     printf("error importing private key\n");
     return nil;
   }
-  
+
   if (EC_KEY_check_key(ec) != 1) {
     printf("error checking key\n");
     EC_KEY_free(ec);
     return nil;
   }
-  
+
   pkey = EVP_PKEY_new();
   if (pkey == NULL) {
     printf("failed to init pkey\n");
     EC_KEY_free(ec);
     return nil;
   }
-  
+
   if (EVP_PKEY_assign_EC_KEY(pkey, ec) != 1) {
     printf("failed to assing ec to pkey\n");
     EC_KEY_free(ec);
     EVP_PKEY_free(pkey);
     return nil;
   }
-  
+
   // `ec` memory is managed by `pkey` from here.
 
   if (EVP_SignInit(&ctx, EVP_sha256()) != 1) {
@@ -121,7 +120,7 @@ const int cert_len = 281;
     EVP_PKEY_free(pkey);
     return nil;
   }
-  
+
   sig = (unsigned char *)malloc(EVP_PKEY_size(pkey));
   if (sig == NULL) {
     printf("failed to malloc for sig\n");

--- a/SelfSignedCertificate/private.h
+++ b/SelfSignedCertificate/private.h
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/7/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 #ifndef private_h

--- a/SelfSignedCertificate/public.h
+++ b/SelfSignedCertificate/public.h
@@ -3,7 +3,6 @@
 //  SelfSignedCertificate
 //
 //  Created by Benjamin P Toews on 8/19/16.
-//  Copyright © 2017 GitHub, inc. All rights reserved.
 //
 
 #ifndef public_h

--- a/SelfSignedCertificateTests/SelfSignedCertificateTests.swift
+++ b/SelfSignedCertificateTests/SelfSignedCertificateTests.swift
@@ -3,7 +3,6 @@
 //  SelfSignedCertificateTests
 //
 //  Created by Benjamin P Toews on 2/7/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest
@@ -12,12 +11,12 @@ import SelfSignedCertificate
 class SelfSignedCertificateTests: XCTestCase {
     func testParseX509() {
         guard var der = SelfSignedCertificate.toDer() else { XCTFail("Error DER formatting cert"); return }
-        
+
         let crtLen = der.count
         var parsedLen = 0
-        
+
         der.append(Data(bytes: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]))
-        
+
         XCTAssert(SelfSignedCertificate.parseX509(der, consumed: &parsedLen), "Error parsing cert")
         XCTAssertEqual(crtLen, parsedLen)
     }

--- a/SoftU2FDriver/SoftU2FDevice.cpp
+++ b/SoftU2FDriver/SoftU2FDevice.cpp
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/12/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 #include "SoftU2FDevice.hpp"

--- a/SoftU2FDriver/SoftU2FDevice.hpp
+++ b/SoftU2FDriver/SoftU2FDevice.hpp
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/12/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 #ifndef SoftU2FDevice_hpp

--- a/SoftU2FDriver/SoftU2FDriver.cpp
+++ b/SoftU2FDriver/SoftU2FDriver.cpp
@@ -3,7 +3,7 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/12/17.
-//  Copyright © 2017 GitHub. All rights reserved.
+//
 
 #include <IOKit/IOLib.h>
 #include "SoftU2FDriver.hpp"

--- a/SoftU2FDriver/SoftU2FDriver.hpp
+++ b/SoftU2FDriver/SoftU2FDriver.hpp
@@ -3,7 +3,7 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/12/17.
-//  Copyright © 2017 GitHub. All rights reserved.
+//
 
 #ifndef SoftU2FDriver_hpp
 #define SoftU2FDriver_hpp

--- a/SoftU2FDriver/SoftU2FUserClient.cpp
+++ b/SoftU2FDriver/SoftU2FUserClient.cpp
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/12/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 #include "SoftU2FUserClient.hpp"

--- a/SoftU2FDriver/SoftU2FUserClient.hpp
+++ b/SoftU2FDriver/SoftU2FUserClient.hpp
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/12/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 #ifndef SoftU2FUserClient_hpp

--- a/SoftU2FDriver/UserKernelShared.h
+++ b/SoftU2FDriver/UserKernelShared.h
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/12/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 #ifndef UserKernelShared_h

--- a/SoftU2FDriverLib/internal.h
+++ b/SoftU2FDriverLib/internal.h
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/25/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 #ifndef internal_h

--- a/SoftU2FDriverLib/softu2f.c
+++ b/SoftU2FDriverLib/softu2f.c
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/12/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 #include "softu2f.h"

--- a/SoftU2FDriverLib/softu2f.h
+++ b/SoftU2FDriverLib/softu2f.h
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/12/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 #ifndef SoftU2FClientInterface_h

--- a/SoftU2FTool/AppDelegate.swift
+++ b/SoftU2FTool/AppDelegate.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/24/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Cocoa
@@ -22,7 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             print("Error stopping authenticator")
         }
     }
-    
+
     func applicationDidBecomeActive(_ notification: Notification) {
         // Chrome gives ignores our U2F responses if it isn't active when we send them.
         // This hack should give focus back to Chrome immediately after the user interacts

--- a/SoftU2FTool/KeyPair.swift
+++ b/SoftU2FTool/KeyPair.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/2/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/SoftU2FTool/Keychain.swift
+++ b/SoftU2FTool/Keychain.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/2/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/SoftU2FTool/KnownFacets.swift
+++ b/SoftU2FTool/KnownFacets.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/27/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/SoftU2FTool/SHA256.swift
+++ b/SoftU2FTool/SHA256.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/10/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/SoftU2FTool/U2FAuthenticator.swift
+++ b/SoftU2FTool/U2FAuthenticator.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/25/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -44,7 +43,7 @@ class U2FAuthenticator {
     func installMsgHandler() {
         u2fhid.handle(.Msg) { (_ msg: softu2f_hid_message) -> Bool in
             let data = msg.data.takeUnretainedValue() as Data
-            
+
             do {
                 let ins = try APDU.commandType(raw: data)
 
@@ -63,14 +62,14 @@ class U2FAuthenticator {
             } catch {
                 self.sendError(status: .OtherError, cid: msg.cid)
             }
-            
+
             return true
         }
     }
 
     func handleRegisterRequest(_ raw: Data, cid: UInt32) throws {
         let req = try APDU.RegisterRequest(raw: raw)
-        
+
         let facet = KnownFacets[req.applicationParameter]
         let notification = UserPresence.Notification.Register(facet: facet)
 
@@ -94,7 +93,7 @@ class U2FAuthenticator {
 
             let payloadSize = 1 + req.applicationParameter.count + req.challengeParameter.count + reg.keyHandle.count + publicKey.count
             var sigPayload = Data(capacity: payloadSize)
-            
+
             sigPayload.append(UInt8(0x00)) // reserved
             sigPayload.append(req.applicationParameter)
             sigPayload.append(req.challengeParameter)
@@ -115,7 +114,7 @@ class U2FAuthenticator {
 
     func handleAuthenticationRequest(_ raw: Data, cid: UInt32) throws {
         let req = try APDU.AuthenticationRequest(raw: raw)
-        
+
         guard let reg = U2FRegistration(keyHandle: req.keyHandle, applicationParameter: req.applicationParameter) else {
             sendError(status: .WrongData, cid: cid)
             return
@@ -138,7 +137,7 @@ class U2FAuthenticator {
 
             let counter = reg.counter
             var ctrBigEndian = counter.bigEndian
-            
+
             let payloadSize = req.applicationParameter.count + 1 + MemoryLayout<UInt32>.size + req.challengeParameter.count
             var sigPayload = Data(capacity: payloadSize)
 

--- a/SoftU2FTool/U2FHID.swift
+++ b/SoftU2FTool/U2FHID.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/25/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -58,7 +57,7 @@ class U2FHID {
         msg.cmd = MessageType.Msg.rawValue
         msg.bcnt = UInt16(data.count)
         msg.cid = cid
-        
+
         let cfd = data as CFData
         msg.data = Unmanaged.passUnretained(cfd)
 

--- a/SoftU2FTool/U2FRegistration.swift
+++ b/SoftU2FTool/U2FRegistration.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/30/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -50,14 +49,14 @@ class U2FRegistration {
 
         // Read our application parameter from the keychain and make sure it matches.
         guard let appTag = keyPair.applicationTag else { return nil }
-        
+
         let counterSize = MemoryLayout<UInt32>.size
         let appTagSize = Int(U2F_APPID_SIZE)
-        
+
         if appTag.count != counterSize + appTagSize {
             return nil
         }
-        
+
         counter = appTag.withUnsafeBytes { (ptr:UnsafePointer<UInt32>) -> UInt32 in
             return ptr.pointee.bigEndian
         }
@@ -93,7 +92,7 @@ class U2FRegistration {
         let appTagSize = Int(U2F_APPID_SIZE)
         var data = Data(capacity: counterSize + appTagSize)
         var ctrBigEndian = counter.bigEndian
-        
+
         data.append(Data(bytes: &ctrBigEndian, count: counterSize))
         data.append(applicationParameter)
 

--- a/SoftU2FTool/UserPresence.swift
+++ b/SoftU2FTool/UserPresence.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/27/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation
@@ -44,7 +43,7 @@ class UserPresence: NSObject {
         } else {
             // Fail any outstanding test.
             current?.complete(false)
-            
+
             // Backup previous delegate to restore on completion.
             let delegateWas = NSUserNotificationCenter.default.delegate
 
@@ -82,7 +81,7 @@ class UserPresence: NSObject {
     func test(_ type: Notification) {
         if #available(OSX 10.12.2, *) {
             let ctx = LAContext()
-            
+
             if ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
                 ctx.localizedCancelTitle = "Reject"
                 ctx.localizedFallbackTitle = "Skip TouchID"
@@ -94,13 +93,13 @@ class UserPresence: NSObject {
                 case let .Authenticate(facet):
                     prompt = "authenticate with " + (facet ?? "site")
                 }
-                
+
                 ctx.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: prompt) { (success, err) in
                     guard let lerr = err as? LAError else {
                         self.complete(success)
                         return
                     }
-                    
+
                     switch lerr.code {
                     case .userFallback, .touchIDNotAvailable, .touchIDNotEnrolled:
                         self.sendNotification(type)

--- a/SoftU2FTool/Utils.swift
+++ b/SoftU2FTool/Utils.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/31/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/SoftU2FTool/WebSafeBase64.swift
+++ b/SoftU2FTool/WebSafeBase64.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/13/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import Foundation

--- a/SoftU2FToolTests/IntegrationTests.swift
+++ b/SoftU2FToolTests/IntegrationTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/27/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/SoftU2FToolTests/SHA256Tests.swift
+++ b/SoftU2FToolTests/SHA256Tests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/10/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/SoftU2FToolTests/SoftU2FTestCase.swift
+++ b/SoftU2FToolTests/SoftU2FTestCase.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/30/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/SoftU2FToolTests/TestUtil.swift
+++ b/SoftU2FToolTests/TestUtil.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/10/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/SoftU2FToolTests/U2FHIDTests.swift
+++ b/SoftU2FToolTests/U2FHIDTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/25/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/SoftU2FToolTests/U2FRegistrationTests.swift
+++ b/SoftU2FToolTests/U2FRegistrationTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 1/31/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/SoftU2FToolTests/UtilsTests.swift
+++ b/SoftU2FToolTests/UtilsTests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 2/1/17.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/SoftU2FToolTests/WebSafeBase64Tests.swift
+++ b/SoftU2FToolTests/WebSafeBase64Tests.swift
@@ -3,7 +3,6 @@
 //  SoftU2F
 //
 //  Created by Benjamin P Toews on 9/13/16.
-//  Copyright © 2017 GitHub. All rights reserved.
 //
 
 import XCTest

--- a/inc/LICENSE-fido-u2f-specification
+++ b/inc/LICENSE-fido-u2f-specification
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+	wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More_considerations
+     for the public:
+	wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/inc/LICENSE-libu2f-host
+++ b/inc/LICENSE-libu2f-host
@@ -1,0 +1,502 @@
+GNU LESSER GENERAL PUBLIC LICENSE
+     Version 2.1, February 1999
+
+Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+as the successor of the GNU Library Public License, version 2, hence
+the version number 2.1.]
+
+          Preamble
+
+The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+GNU LESSER GENERAL PUBLIC LICENSE
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+a) The modified work must itself be a software library.
+
+b) You must cause the files modified to carry prominent notices
+stating that you changed the files and the date of any change.
+
+c) You must cause the whole of the work to be licensed at no
+charge to all third parties under the terms of this License.
+
+d) If a facility in the modified Library refers to a function or a
+table of data to be supplied by an application program that uses
+the facility, other than as an argument passed when the facility
+is invoked, then you must make a good faith effort to ensure that,
+in the event an application does not supply such function or
+table, the facility still operates, and performs whatever part of
+its purpose remains meaningful.
+
+(For example, a function in a library to compute square roots has
+a purpose that is entirely well-defined independent of the
+application.  Therefore, Subsection 2d requires that any
+application-supplied function or table used by this function must
+be optional: if the application does not supply it, the square
+root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+a) Accompany the work with the complete corresponding
+machine-readable source code for the Library including whatever
+changes were used in the work (which must be distributed under
+Sections 1 and 2 above); and, if the work is an executable linked
+with the Library, with the complete machine-readable "work that
+uses the Library", as object code and/or source code, so that the
+user can modify the Library and then relink to produce a modified
+executable containing the modified Library.  (It is understood
+that the user who changes the contents of definitions files in the
+Library will not necessarily be able to recompile the application
+to use the modified definitions.)
+
+b) Use a suitable shared library mechanism for linking with the
+Library.  A suitable mechanism is one that (1) uses at run time a
+copy of the library already present on the user's computer system,
+rather than copying library functions into the executable, and (2)
+will operate properly with a modified version of the library, if
+the user installs one, as long as the modified version is
+interface-compatible with the version that the work was made with.
+
+c) Accompany the work with a written offer, valid for at
+least three years, to give the same user the materials
+specified in Subsection 6a, above, for a charge no more
+than the cost of performing this distribution.
+
+d) If distribution of the work is made by offering access to copy
+from a designated place, offer equivalent access to copy the above
+specified materials from the same place.
+
+e) Verify that the user has already received a copy of these
+materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+a) Accompany the combined library with a copy of the same work
+based on the Library, uncombined with any other library
+facilities.  This must be distributed under the terms of the
+Sections above.
+
+b) Give prominent notice with the combined library of the fact
+that part of it is a work based on the Library, and explaining
+where to find the accompanying uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+          NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+   END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+<one line to give the library's name and a brief idea of what it does.>
+Copyright (C) <year>  <name of author>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in the
+library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+<signature of Ty Coon>, 1 April 1990
+Ty Coon, President of Vice
+
+That's all there is to it!

--- a/inc/u2f.h
+++ b/inc/u2f.h
@@ -1,6 +1,11 @@
-// Common U2F raw message format header - Review Draft
-// 2014-10-08
-// Editor: Jakob Ehrensvard, Yubico, jakob@yubico.com
+/**
+ * Copyright FIDO Alliance, 2017
+ *
+ * Licensed under CC-BY:
+ * https://creativecommons.org/licenses/by/4.0/legalcode
+ *
+ * Editor: Jakob Ehrensvard, Yubico, jakob@yubico.com
+ */
 
 #ifndef __U2F_H_INCLUDED__
 #define __U2F_H_INCLUDED__

--- a/inc/u2f_hid.h
+++ b/inc/u2f_hid.h
@@ -1,6 +1,11 @@
-// Common U2F HID transport header - Review Draft
-// 2014-10-08
-// Editor: Jakob Ehrensvard, Yubico, jakob@yubico.com
+/**
+ * Copyright FIDO Alliance, 2017
+ *
+ * Licensed under CC-BY:
+ * https://creativecommons.org/licenses/by/4.0/legalcode
+ *
+ * Editor: Jakob Ehrensvard, Yubico, jakob@yubico.com
+ */
 
 #ifndef __U2FHID_H_INCLUDED__
 #define __U2FHID_H_INCLUDED__

--- a/inc/u2f_hid.h
+++ b/inc/u2f_hid.h
@@ -18,15 +18,15 @@ typedef unsigned long int uint64_t;
 extern "C" {
 #endif
 
-// Size of HID reports 
+// Size of HID reports
 
 #define HID_RPT_SIZE            64      // Default size of raw HID report
-    
+
 // Frame layout - command- and continuation frames
 
 #define CID_BROADCAST           0xffffffff // Broadcast channel id
 
-#define TYPE_MASK               0x80    // Frame type mask 
+#define TYPE_MASK               0x80    // Frame type mask
 #define TYPE_INIT               0x80    // Initial frame identifier
 #define TYPE_CONT               0x00    // Continuation frame identifier
 
@@ -58,8 +58,8 @@ typedef struct __attribute__((packed)) {
 #define FIDO_USAGE_U2FHID       0x01    // U2FHID usage for top-level collection
 #define FIDO_USAGE_DATA_IN      0x20    // Raw IN data report
 #define FIDO_USAGE_DATA_OUT     0x21    // Raw OUT data report
-        
-// General constants    
+
+// General constants
 
 #define U2FHID_IF_VERSION       2       // Current interface implementation version
 #define U2FHID_TRANS_TIMEOUT    3000    // Default message timeout in ms
@@ -76,7 +76,7 @@ typedef struct __attribute__((packed)) {
 
 #define U2FHID_VENDOR_FIRST (TYPE_INIT | 0x40)  // First vendor defined command
 #define U2FHID_VENDOR_LAST  (TYPE_INIT | 0x7f)  // Last vendor defined command
-    
+
 // U2FHID_INIT command defines
 
 #define INIT_NONCE_SIZE         8       // Size of channel initialization challenge
@@ -89,12 +89,12 @@ typedef struct __attribute__((packed)) {
 
 typedef struct __attribute__((packed)) {
   uint8_t nonce[INIT_NONCE_SIZE];       // Client application nonce
-  uint32_t cid;                         // Channel identifier  
+  uint32_t cid;                         // Channel identifier
   uint8_t versionInterface;             // Interface version
   uint8_t versionMajor;                 // Major version number
   uint8_t versionMinor;                 // Minor version number
   uint8_t versionBuild;                 // Build version number
-  uint8_t capFlags;                     // Capabilities flags  
+  uint8_t capFlags;                     // Capabilities flags
 } U2FHID_INIT_RESP;
 
 // U2FHID_SYNC command defines


### PR DESCRIPTION
This PR aims to fix up the licenses included in this project.

- Remove the confusing copyright notice that XCode adds to every file.
- Add libu2f-host's license to the `/inc` dir.
- Add a note to README, calling out the licenses in the `/inc` dir.

I'm waiting to hear back from the FIDO Alliance about the license that `u2f.h` and `u2f_hid.h` are published under.

/cc @mlinksva 