### PR TITLE
Installer script fixes

### DIFF
--- a/install-scripts/postinstall
+++ b/install-scripts/postinstall
@@ -30,9 +30,9 @@ cat > $LAUNCH_AGENT_PLIST << EOT
 EOT
 
 # Make sure the plist is owned by the user (otherwise it runs as root)
-chown ${USER}:staff $LAUNCH_AGENT_PLIST
+chown "${USER}:staff" $LAUNCH_AGENT_PLIST
 
 # Launch the app
-sudo -u${USER} launchctl load $LAUNCH_AGENT_PLIST
+sudo -u "${USER}" launchctl load $LAUNCH_AGENT_PLIST
 
 exit 0

--- a/install-scripts/preinstall
+++ b/install-scripts/preinstall
@@ -4,4 +4,4 @@ KEXT="/Library/Extensions/softu2f.kext"
 LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/com.github.SoftU2F.plist"
 
 kextunload $KEXT || true
-launchctl unload $LAUNCH_AGENT_PLIST || true
+sudo -u "${USER}" launchctl unload $LAUNCH_AGENT_PLIST || true


### PR DESCRIPTION
This PR makes two fixes. It updates the postinstall script to consider usernames with spaces. It also updates the preinstall script to run `launchctl unload` as the correct user. Previously, the agent wasn't getting unloaded during upgrades, meaning the old binary would keep running until the next system restart.

/cc Heads up to @Hygelac @alexandernilsson
fixes #8