### PR TITLE
Return correct HID metadata

### DIFF
--- a/SoftU2F.xcodeproj/project.pbxproj
+++ b/SoftU2F.xcodeproj/project.pbxproj
@@ -403,12 +403,12 @@
 			isa = PBXGroup;
 			children = (
 				F725EBCE1F1FAD9B000A003C /* UserKernelShared.h */,
-				F725EBCF1F1FAD9B000A003C /* SoftU2FDevice.hpp */,
 				F725EBD01F1FAD9B000A003C /* SoftU2FDriver.hpp */,
-				F725EBD11F1FAD9B000A003C /* SoftU2FUserClient.hpp */,
-				F725EBD21F1FAD9B000A003C /* SoftU2FDevice.cpp */,
 				F725EBD31F1FAD9B000A003C /* SoftU2FDriver.cpp */,
+				F725EBD11F1FAD9B000A003C /* SoftU2FUserClient.hpp */,
 				F725EBD41F1FAD9B000A003C /* SoftU2FUserClient.cpp */,
+				F725EBCF1F1FAD9B000A003C /* SoftU2FDevice.hpp */,
+				F725EBD21F1FAD9B000A003C /* SoftU2FDevice.cpp */,
 				F725EBD51F1FAD9B000A003C /* Info.plist */,
 			);
 			path = SoftU2FDriver;

--- a/SoftU2F.xcodeproj/xcshareddata/xcschemes/SoftU2F.xcscheme
+++ b/SoftU2F.xcodeproj/xcshareddata/xcschemes/SoftU2F.xcscheme
@@ -51,11 +51,6 @@
                BlueprintName = "SoftU2FTests"
                ReferencedContainer = "container:SoftU2F.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "IntegrationTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/SoftU2FDriver/SoftU2FDevice.cpp
+++ b/SoftU2FDriver/SoftU2FDevice.cpp
@@ -8,6 +8,7 @@
 #include "SoftU2FDevice.hpp"
 #include "SoftU2FUserClient.hpp"
 #include <IOKit/IOLib.h>
+#include "u2f_hid.h"
 
 #define super IOHIDDevice
 OSDefineMetaClassAndStructors(SoftU2FDevice, IOHIDDevice)
@@ -66,6 +67,10 @@ OSNumber *SoftU2FDevice::newProductIDNumber() const {
   return OSNumber::withNumber(123, 32);
 }
 
+OSNumber* SoftU2FDevice::newPrimaryUsagePageNumber() const {
+  return OSNumber::withNumber(FIDO_USAGE_PAGE, 32);
+}
+
 OSNumber* SoftU2FDevice::newPrimaryUsageNumber() const {
-  return OSNumber::withNumber(kHIDUsage_PID_TriggerButton, 32);
+  return OSNumber::withNumber(FIDO_USAGE_U2FHID, 32);
 }

--- a/SoftU2FDriver/SoftU2FDevice.hpp
+++ b/SoftU2FDriver/SoftU2FDevice.hpp
@@ -41,6 +41,7 @@ public:
   virtual OSString *newSerialNumberString() const override;
   virtual OSNumber *newVendorIDNumber() const override;
   virtual OSNumber *newProductIDNumber() const override;
+  virtual OSNumber *newPrimaryUsagePageNumber() const override;
   virtual OSNumber *newPrimaryUsageNumber() const override;
   virtual IOReturn newReportDescriptor(IOMemoryDescriptor **descriptor) const override;
   virtual IOReturn setReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options = 0) override;


### PR DESCRIPTION
I had started working on fixing https://github.com/mastahyeti/softu2f-legacy-driver/issues/9 and never copied in the correct values for usage page number and usage number. This broke Soft U2F's compatibility with libu2f-host, which broke the integration test as well as compatibility with the Firefox U2F extension. This PR sets the correct values and reenables the integration test.

/cc @stephenyeargin 
/fixes #15 
/fixes https://github.com/mastahyeti/softu2f-legacy-driver/issues/9