### PR TITLE
Updating installer download to newest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We take the security of this project seriously. Report any security vulnerabilit
 
 ## Installing
 
-You can download the installer [here](https://github.com/github/SoftU2F/releases/download/0.0.8/SoftU2F.pkg).
+You can download the installer [here](https://github.com/github/SoftU2F/releases/download/0.0.10/SoftU2F.pkg).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We take the security of this project seriously. Report any security vulnerabilit
 
 ## Installing
 
-You can download the installer [here](https://github.com/github/SoftU2F/releases/download/0.0.10/SoftU2F.pkg).
+You can download the installer [here](https://github.com/github/SoftU2F/releases/latest).
 
 ## Usage
 


### PR DESCRIPTION
Would have liked to use the `latest` keyword, but there doesn't seem to be a wait to do that whilst linking directly to the file itself