### PR TITLE
Hack to get things working on High Sierra

### DIFF
--- a/SoftU2FTool/UserPresence.swift
+++ b/SoftU2FTool/UserPresence.swift
@@ -174,12 +174,17 @@ class UserPresence: NSObject {
 
 extension UserPresence: NSUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: NSUserNotificationCenter, didDeliver notification: NSUserNotification) {
-        if notification.isPresented {
+        if #available(OSX 10.13, *) {
+          // notification.isPresented is always false on the latest 10.13 beta.
+          installTimer()
+        } else {
+          if notification.isPresented {
             // Alert is showing to user. Watch to see if it's dismissed.
             installTimer()
-        } else {
+          } else {
             // Alert wasn't shown to user. Fail.
             complete(false)
+          }
         }
     }
 


### PR DESCRIPTION
This is a quick fix for https://github.com/github/SoftU2F/issues/20. On High Sierra, `notification.isPresented` is always false in `userNotificationCenter(_:didDeliver:)`, so we just skip checking it.

If anyone has thoughts on a better fix, I'm still open to suggestions.