### PR TITLE
added known facet for bitwarden

### DIFF
--- a/SoftU2FTool/KnownFacets.swift
+++ b/SoftU2FTool/KnownFacets.swift
@@ -11,5 +11,6 @@ let KnownFacets: [Data: String] = [
     SHA256.digest("https://github.com/u2f/trusted_facets"): "https://github.com",
     SHA256.digest("https://demo.yubico.com"): "https://demo.yubico.com",
     SHA256.digest("https://www.dropbox.com/u2f-app-id.json"): "https://dropbox.com",
-    SHA256.digest("https://www.gstatic.com/securitykey/origins.json"): "https://google.com"
+    SHA256.digest("https://www.gstatic.com/securitykey/origins.json"): "https://google.com",
+    SHA256.digest("https://vault.bitwarden.com/app-id.json"): "https://vault.bitwarden.com"
 ]


### PR DESCRIPTION
bitwarden is a popular open source password manager that [supports FIDO U2F security keys](https://help.bitwarden.com/article/setup-two-step-login-u2f/). This PR adds the facet endpoint for bitwarden as described in the README.