### PR TITLE
Only allow one running instance of app

### DIFF
--- a/SoftU2FDriver/SoftU2FDriver.cpp
+++ b/SoftU2FDriver/SoftU2FDriver.cpp
@@ -35,3 +35,15 @@ void SoftU2FDriver::free() {
 IOWorkLoop* SoftU2FDriver::getWorkLoop() const {
   return _workLoop;
 }
+
+IOReturn SoftU2FDriver::newUserClient(task_t owningTask, void *securityID, UInt32 type, OSDictionary *properties, IOUserClient **handler) {
+  IOLog("%s[%p]::%s()\n", getName(), this, __FUNCTION__);
+
+  // Check that another client isn't already connected.
+  if (getClient()) {
+    IOLog("%s[%p]::%s() -> kIOReturnExclusiveAccess\n", getName(), this, __FUNCTION__);
+    return kIOReturnExclusiveAccess;
+  }
+
+  return super::newUserClient(owningTask, securityID, type, properties, handler);
+}

--- a/SoftU2FDriver/SoftU2FDriver.hpp
+++ b/SoftU2FDriver/SoftU2FDriver.hpp
@@ -20,6 +20,8 @@ public :
   virtual bool start(IOService *provider) override;
   void free() override;
   IOWorkLoop* getWorkLoop() const override;
+
+  virtual IOReturn newUserClient(task_t owningTask, void *securityID, UInt32 type, OSDictionary *properties, IOUserClient **handler) override;
 };
 
 #endif /* SoftU2F_hpp */

--- a/SoftU2FTool/AppDelegate.swift
+++ b/SoftU2FTool/AppDelegate.swift
@@ -12,12 +12,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         if !U2FAuthenticator.start() {
             print("Error starting authenticator")
+            NSApplication.shared().terminate(self)
         }
 
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
-        if !U2FAuthenticator.stop() {
+        if U2FAuthenticator.shared != nil && !U2FAuthenticator.stop() {
             print("Error stopping authenticator")
         }
     }


### PR DESCRIPTION
There's some weird behavior when you try to run multiple instances of the app at the same time. You should wind up with two HID devices in the registry, but they somehow mess with each other and neither of them end up working. This is problematic because people try to launch the `SoftU2F.app`, even though the launchd agent is already running in the background.

This PR adds a check to the driver that returns an error when trying to get a new userclient if one is already attached.