### PR TITLE
Optionally store keys in SEP

### DIFF
--- a/SoftU2F.xcodeproj/project.pbxproj
+++ b/SoftU2F.xcodeproj/project.pbxproj
@@ -97,6 +97,8 @@
 		F7B5DBC31E4A85EB00E5ABD4 /* VersionRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7B5DBBF1E4A85EB00E5ABD4 /* VersionRequestTests.swift */; };
 		F7B5DBC91E4A8CF000E5ABD4 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7B5DBC81E4A8CF000E5ABD4 /* Response.swift */; };
 		F7B5DBCA1E4A8CF000E5ABD4 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7B5DBC81E4A8CF000E5ABD4 /* Response.swift */; };
+		F7DD7DE81F313E65007F056E /* CLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7DD7DE71F313E65007F056E /* CLI.swift */; };
+		F7DD7DEA1F324EE0007F056E /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7DD7DE91F324EE0007F056E /* Settings.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -249,6 +251,8 @@
 		F7B5DBBE1E4A85EB00E5ABD4 /* RegisterRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegisterRequestTests.swift; sourceTree = "<group>"; };
 		F7B5DBBF1E4A85EB00E5ABD4 /* VersionRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionRequestTests.swift; sourceTree = "<group>"; };
 		F7B5DBC81E4A8CF000E5ABD4 /* Response.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
+		F7DD7DE71F313E65007F056E /* CLI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CLI.swift; sourceTree = "<group>"; };
+		F7DD7DE91F324EE0007F056E /* Settings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -374,6 +378,8 @@
 				51213EC51E3916EB005454E0 /* U2FHID.swift */,
 				51B289E41E39903F00AD90CC /* U2FAuthenticator.swift */,
 				51FE30EC1E403DA000BAE824 /* U2FRegistration.swift */,
+				F7DD7DE71F313E65007F056E /* CLI.swift */,
+				F7DD7DE91F324EE0007F056E /* Settings.swift */,
 				518537BF1E380E4600600911 /* SoftU2F-Bridging-Header.h */,
 				51F090181E37E8C600F03AD3 /* Info.plist */,
 			);
@@ -843,12 +849,14 @@
 			files = (
 				5190B6121E3BFE3D00E6FE06 /* UserPresence.swift in Sources */,
 				51FE30F11E410B3D00BAE824 /* Utils.swift in Sources */,
+				F7DD7DEA1F324EE0007F056E /* Settings.swift in Sources */,
 				5119862E1E3C1519006A3BBB /* KnownFacets.swift in Sources */,
 				51F090101E37E8C600F03AD3 /* AppDelegate.swift in Sources */,
 				51213EC61E3916EB005454E0 /* U2FHID.swift in Sources */,
 				51E214601E3823E7005B2864 /* SHA256.swift in Sources */,
 				51B289E51E39903F00AD90CC /* U2FAuthenticator.swift in Sources */,
 				514F3D821E43C833008FA513 /* Keychain.swift in Sources */,
+				F7DD7DE81F313E65007F056E /* CLI.swift in Sources */,
 				51FE30ED1E403DA000BAE824 /* U2FRegistration.swift in Sources */,
 				51E214621E382521005B2864 /* WebSafeBase64.swift in Sources */,
 				514F3D871E43E828008FA513 /* KeyPair.swift in Sources */,

--- a/SoftU2FTool/AppDelegate.swift
+++ b/SoftU2FTool/AppDelegate.swift
@@ -7,24 +7,15 @@
 
 import Cocoa
 
-let listKeysArgument = "--list"
-
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        if CommandLine.arguments.contains(listKeysArgument) {
-            listKeys()
+        if CLI(CommandLine.arguments).run() {
             quit()
-            return
-        }
-      
-      
-        if !U2FAuthenticator.start() {
+        } else if !U2FAuthenticator.start(){
             print("Error starting authenticator")
             quit()
-            return
         }
-
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
@@ -39,28 +30,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // with our notification.
         NSApplication.shared().hide(nil)
     }
-    
+
     private func quit() {
         NSApplication.shared().terminate(self)
-    }
-  
-    private func listKeys() {
-        if let numRegs = U2FRegistration.count {
-            print("Registrations: ", numRegs)
-        }
-        
-        U2FRegistration.all.forEach { reg in
-            print("base64(key handle): ", reg.keyHandle.base64EncodedString())
-            print("base64(sha256(appid)): ", reg.applicationParameter.base64EncodedString())
-            
-            if let kf = KnownFacets[reg.applicationParameter] {
-                print("site: ", kf)
-            } else {
-                print("site: unknown")
-            }
-            
-            print("counter: ", reg.counter)
-            print("")
-        }
     }
 }

--- a/SoftU2FTool/AppDelegate.swift
+++ b/SoftU2FTool/AppDelegate.swift
@@ -10,6 +10,8 @@ import Cocoa
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        U2FRegistration.repair()
+
         if CLI(CommandLine.arguments).run() {
             quit()
         } else if !U2FAuthenticator.start(){

--- a/SoftU2FTool/AppDelegate.swift
+++ b/SoftU2FTool/AppDelegate.swift
@@ -10,6 +10,7 @@ import Cocoa
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        // Fix up legacy keychain items.
         U2FRegistration.repair()
 
         if CLI(CommandLine.arguments).run() {
@@ -27,7 +28,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
-        // Chrome gives ignores our U2F responses if it isn't active when we send them.
+        // Chrome ignores our U2F responses if it isn't active when we send them.
         // This hack should give focus back to Chrome immediately after the user interacts
         // with our notification.
         NSApplication.shared().hide(nil)

--- a/SoftU2FTool/AppDelegate.swift
+++ b/SoftU2FTool/AppDelegate.swift
@@ -7,17 +7,28 @@
 
 import Cocoa
 
+let listKeysArgument = "--list"
+
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        if CommandLine.arguments.contains(listKeysArgument) {
+            listKeys()
+            quit()
+            return
+        }
+      
+      
         if !U2FAuthenticator.start() {
             print("Error starting authenticator")
+            quit()
+            return
         }
 
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
-        if !U2FAuthenticator.stop() {
+        if U2FAuthenticator.running && !U2FAuthenticator.stop() {
             print("Error stopping authenticator")
         }
     }
@@ -27,5 +38,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // This hack should give focus back to Chrome immediately after the user interacts
         // with our notification.
         NSApplication.shared().hide(nil)
+    }
+    
+    private func quit() {
+        NSApplication.shared().terminate(self)
+    }
+  
+    private func listKeys() {
+        if let numRegs = U2FRegistration.count {
+            print("Registrations: ", numRegs)
+        }
+        
+        U2FRegistration.all.forEach { reg in
+            print("base64(key handle): ", reg.keyHandle.base64EncodedString())
+            print("base64(sha256(appid)): ", reg.applicationParameter.base64EncodedString())
+            
+            if let kf = KnownFacets[reg.applicationParameter] {
+                print("site: ", kf)
+            } else {
+                print("site: unknown")
+            }
+            
+            print("counter: ", reg.counter)
+            print("")
+        }
     }
 }

--- a/SoftU2FTool/CLI.swift
+++ b/SoftU2FTool/CLI.swift
@@ -43,6 +43,12 @@ class CLI {
     }
 
     private func listRegistrations() {
+        let registrations = U2FRegistration.all
+        if registrations.count == 0 {
+            print("No registrations to list")
+            return
+        }
+        
         print("The following is a list of U2F registrations stored in your keychain. Each key contains several fields:")
         print("  - Key handle: This is the key handle that we registered with a website. For Soft U2F, the key handle is simply a hash of the public key.")
         print("  - Application parameter: This is the sha256 of the app-id of the site.")
@@ -51,7 +57,7 @@ class CLI {
         print("  — In SEP: Whether this registration's private key is stored in the SEP.")
         print("")
 
-        U2FRegistration.all.forEach { reg in
+        registrations.forEach { reg in
             print("Key handle: ", reg.keyHandle.base64EncodedString())
             print("Application parameter: ", reg.applicationParameter.base64EncodedString())
 

--- a/SoftU2FTool/CLI.swift
+++ b/SoftU2FTool/CLI.swift
@@ -45,6 +45,7 @@ class CLI {
         print("  - Application parameter: This is the sha256 of the app-id of the site.")
         print("  - Known facet: For some sites we know the application parameter → site name mapping.")
         print("  - Counter: How many times this registration has been used.")
+        print("  — In SEP: Whether this registration's private key is stored in the SEP.")
         print("")
 
         U2FRegistration.all.forEach { reg in
@@ -58,6 +59,7 @@ class CLI {
             }
 
             print("Counter: ", reg.counter)
+            print("In SEP: ", reg.inSEP)
             print("")
         }
     }

--- a/SoftU2FTool/CLI.swift
+++ b/SoftU2FTool/CLI.swift
@@ -13,9 +13,6 @@ fileprivate let deleteAllFlag = "--delete-all"
 fileprivate let showSEPFlag = "--show-sep"
 fileprivate let enableSEPFlag = "--enable-sep"
 fileprivate let disableSEPFlag = "--disable-sep"
-fileprivate let showTouchidFlag = "--show-touchid"
-fileprivate let enableTouchidFlag = "--enable-touchid"
-fileprivate let disableTouchidFlag = "--disable-touchid"
 
 class CLI {
     private let args: [String]
@@ -30,15 +27,6 @@ class CLI {
             return true
         } else if args.contains(deleteAllFlag) {
             deleteAll()
-            return true
-        } else if args.contains(showTouchidFlag) {
-            showTouchid()
-            return true
-        } else if args.contains(enableTouchidFlag) {
-            enableTouchid()
-            return true
-        } else if args.contains(disableTouchidFlag) {
-            disableTouchid()
             return true
         } else if args.contains(showSEPFlag) {
             showSEP()
@@ -91,27 +79,6 @@ class CLI {
         }
 
         print("Deleted ", initialCount, " registrations")
-    }
-
-    private func showTouchid() {
-        if Settings.touchidDisabled {
-            print("TouchID is disabled")
-        } else {
-            print("TouchID is enabled")
-        }
-    }
-
-    private func enableTouchid() {
-        if Settings.enableTouchid() {
-            print("TouchID is now enabled")
-        } else {
-            print("Error enabling TouchID. Does your system support it?")
-        }
-    }
-
-    private func disableTouchid() {
-        Settings.disableTouchid()
-        print("TouchID is now disabled")
     }
 
     private func showSEP() {

--- a/SoftU2FTool/CLI.swift
+++ b/SoftU2FTool/CLI.swift
@@ -1,0 +1,96 @@
+//
+//  CLI.swift
+//  SoftU2F
+//
+//  Created by Ben Toews on 8/1/17.
+//
+
+import Foundation
+
+// Command line flags
+fileprivate let listFlag = "--list"
+fileprivate let deleteAllFlag = "--delete-all"
+fileprivate let showSEPFlag = "--show-sep"
+fileprivate let enableSEPFlag = "--enable-sep"
+fileprivate let disableSEPFlag = "--disable-sep"
+
+// Settings keys
+fileprivate let useSEPKey = "useSEP"
+
+class CLI {
+    private let args: [String]
+
+    init(_ arguments: [String]) {
+        args = arguments
+    }
+
+    func run() -> Bool {
+        if args.contains(listFlag) {
+            listRegistrations()
+            return true
+        } else if args.contains(deleteAllFlag) {
+            deleteAll()
+            return true
+        } else if args.contains(showSEPFlag) {
+            showSEP()
+            return true
+        }
+
+        return false
+    }
+
+    private func listRegistrations() {
+        print("The following is a list of U2F registrations stored in your keychain. Each key contains several fields:")
+        print("  - Key handle: This is the key handle that we registered with a website. For Soft U2F, the key handle is simply a hash of the public key.")
+        print("  - Application parameter: This is the sha256 of the app-id of the site.")
+        print("  - Known facet: For some sites we know the application parameter → site name mapping.")
+        print("  - Counter: How many times this registration has been used.")
+        print("")
+
+        U2FRegistration.all.forEach { reg in
+            print("Key handle: ", reg.keyHandle.base64EncodedString())
+            print("Application parameter: ", reg.applicationParameter.base64EncodedString())
+
+            if let kf = KnownFacets[reg.applicationParameter] {
+                print("Known facet: ", kf)
+            } else {
+                print("Known facet: N/A")
+            }
+
+            print("Counter: ", reg.counter)
+            print("")
+        }
+    }
+
+    private func deleteAll() {
+        guard let initialCount = U2FRegistration.count else {
+            print("Error getting registration count from keychain.")
+            return
+        }
+
+        if !U2FRegistration.deleteAll() {
+            print("Error deleting registrations from keychain.")
+            return
+        }
+
+        print("Deleted ", initialCount, " registrations")
+    }
+
+    private func showSEP() {
+        if Settings.sepEnabled {
+            print("SEP storage is enabled for new keys")
+        } else {
+            print("SEP storage is disabled for new keys")
+        }
+    }
+
+    private func enableSEP() {
+        Settings.enableSEP()
+        print("SEP storage is now enabled for new keys")
+    }
+
+    private func disableSEP() {
+        Settings.disableSEP()
+        print("SEP storage is now disabled for new keys")
+    }
+}

--- a/SoftU2FTool/KeyPair.swift
+++ b/SoftU2FTool/KeyPair.swift
@@ -12,14 +12,14 @@ fileprivate class tmpKeyPair {
     var applicationLabel: Data
     var publicKey: SecKey?
     var privateKey: SecKey?
-    
+
     var keyPair: KeyPair? {
         guard let pub = publicKey else { return nil }
         guard let priv = privateKey else { return nil }
-        
+
         return KeyPair(label: label, appLabel: applicationLabel, publicKey: pub, privateKey: priv)
     }
-    
+
     init(label l: String, applicationLabel al: Data) {
         label = l
         applicationLabel = al
@@ -32,38 +32,38 @@ class KeyPair {
         let secKeys = Keychain.getSecKeys(attrLabel: label as CFString)
         var tmpKeyPairs: [tmpKeyPair] = []
         var keyPairs: [KeyPair] = []
-        
+
         secKeys.forEach { secKey in
             guard let appLabel: CFData = Keychain.getSecKeyAttr(key: secKey, attr: kSecAttrApplicationLabel) else { return }
 
             let applicationLabel = appLabel as Data
             var tmpKP: tmpKeyPair
-            
+
             if let kp = tmpKeyPairs.first(where: { $0.applicationLabel == applicationLabel }) {
                 tmpKP = kp
             } else {
                 tmpKP = tmpKeyPair.init(label: label, applicationLabel: applicationLabel)
                 tmpKeyPairs.append(tmpKP)
             }
-            
+
             guard let klass: CFString = Keychain.getSecKeyAttr(key: secKey, attr: kSecAttrKeyClass) else { return }
-            
+
             if klass == kSecAttrKeyClassPublic {
                 tmpKP.publicKey = secKey
             } else {
                 tmpKP.privateKey = secKey
             }
         }
-        
+
         tmpKeyPairs.forEach { tmpKP in
             guard let kp = tmpKP.keyPair else { return }
 
             keyPairs.append(kp)
         }
-        
+
         return keyPairs
     }
-    
+
     // The number of key pairs (keys/2) in the keychain.
     static func count(label: String) -> Int? {
         guard let c = Keychain.count(attrLabel: label as CFString) else { return nil }
@@ -105,11 +105,17 @@ class KeyPair {
         return Keychain.getSecItemData(attrAppLabel: applicationLabel)
     }
 
+    var inSEP: Bool {
+        let tokenID: String = Keychain.getSecItemAttr(attrAppLabel: applicationLabel as CFData, name: kSecAttrTokenID) ?? "nope"
+
+        return tokenID == kSecAttrTokenIDSecureEnclave as String
+    }
+
     // Generate a new key pair.
-    init?(label l: String) {
+    init?(label l: String, inSEP sep: Bool) {
         label = l
 
-        guard let (pub, priv) = Keychain.generateKeyPair(attrLabel: label as CFString) else { return nil }
+        guard let (pub, priv) = Keychain.generateKeyPair(attrLabel: label as CFString, inSEP: sep) else { return nil }
         publicKey = pub
         privateKey = priv
 
@@ -130,7 +136,7 @@ class KeyPair {
         guard let priv = Keychain.getSecKey(attrAppLabel: applicationLabel as CFData, keyClass: kSecAttrKeyClassPrivate) else { return nil }
         privateKey = priv
     }
-    
+
     // Initialize a key pair with all the necessary data.
     init(label l: String, appLabel al: Data, publicKey pub: SecKey, privateKey priv: SecKey) {
         label = l

--- a/SoftU2FTool/KeyPair.swift
+++ b/SoftU2FTool/KeyPair.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 class KeyPair {
+    // Fix up legacy keychain items.
     static func repair(label: String) {
         Keychain.repair(attrLabel: label as CFString)
     }

--- a/SoftU2FTool/KeyPair.swift
+++ b/SoftU2FTool/KeyPair.swift
@@ -7,7 +7,63 @@
 
 import Foundation
 
+fileprivate class tmpKeyPair {
+    var label: String
+    var applicationLabel: Data
+    var publicKey: SecKey?
+    var privateKey: SecKey?
+    
+    var keyPair: KeyPair? {
+        guard let pub = publicKey else { return nil }
+        guard let priv = privateKey else { return nil }
+        
+        return KeyPair(label: label, appLabel: applicationLabel, publicKey: pub, privateKey: priv)
+    }
+    
+    init(label l: String, applicationLabel al: Data) {
+        label = l
+        applicationLabel = al
+    }
+}
+
 class KeyPair {
+    /// Get all KeyPairs with the given label.
+    static func all(label: String) -> [KeyPair] {
+        let secKeys = Keychain.getSecKeys(attrLabel: label as CFString)
+        var tmpKeyPairs: [tmpKeyPair] = []
+        var keyPairs: [KeyPair] = []
+        
+        secKeys.forEach { secKey in
+            guard let appLabel: CFData = Keychain.getSecKeyAttr(key: secKey, attr: kSecAttrApplicationLabel) else { return }
+
+            let applicationLabel = appLabel as Data
+            var tmpKP: tmpKeyPair
+            
+            if let kp = tmpKeyPairs.first(where: { $0.applicationLabel == applicationLabel }) {
+                tmpKP = kp
+            } else {
+                tmpKP = tmpKeyPair.init(label: label, applicationLabel: applicationLabel)
+                tmpKeyPairs.append(tmpKP)
+            }
+            
+            guard let klass: CFString = Keychain.getSecKeyAttr(key: secKey, attr: kSecAttrKeyClass) else { return }
+            
+            if klass == kSecAttrKeyClassPublic {
+                tmpKP.publicKey = secKey
+            } else {
+                tmpKP.privateKey = secKey
+            }
+        }
+        
+        tmpKeyPairs.forEach { tmpKP in
+            guard let kp = tmpKP.keyPair else { return }
+
+            keyPairs.append(kp)
+        }
+        
+        return keyPairs
+    }
+    
     // The number of key pairs (keys/2) in the keychain.
     static func count(label: String) -> Int? {
         guard let c = Keychain.count(attrLabel: label as CFString) else { return nil }
@@ -72,6 +128,14 @@ class KeyPair {
 
         // Lookup private key.
         guard let priv = Keychain.getSecKey(attrAppLabel: applicationLabel as CFData, keyClass: kSecAttrKeyClassPrivate) else { return nil }
+        privateKey = priv
+    }
+    
+    // Initialize a key pair with all the necessary data.
+    init(label l: String, appLabel al: Data, publicKey pub: SecKey, privateKey priv: SecKey) {
+        label = l
+        applicationLabel = al
+        publicKey = pub
         privateKey = priv
     }
 

--- a/SoftU2FTool/KeyPair.swift
+++ b/SoftU2FTool/KeyPair.swift
@@ -82,12 +82,12 @@ class KeyPair {
     }
 
     // Find a key pair with the given label and application label.
-    init?(label l: String, appLabel al: Data) {
+    init?(label l: String, appLabel al: Data, signPrompt sp: String) {
         label = l
         applicationLabel = al
 
         // Lookup private key.
-        guard let priv = Keychain.getPrivateSecKey(attrAppLabel: applicationLabel as CFData) else { return nil }
+        guard let priv = Keychain.getPrivateSecKey(attrAppLabel: applicationLabel as CFData, signPrompt: sp as CFString) else { return nil }
         privateKey = priv
         
         // Generate public key from private key

--- a/SoftU2FTool/Keychain.swift
+++ b/SoftU2FTool/Keychain.swift
@@ -206,7 +206,7 @@ class Keychain {
 
         if inSEP {
             if #available(OSX 10.12.1, *) {
-                acl = SecAccessControlCreateWithFlags(nil, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.privateKeyUsage, .touchIDCurrentSet], &err)
+                acl = SecAccessControlCreateWithFlags(nil, kSecAttrAccessibleWhenUnlocked, [.privateKeyUsage, .touchIDAny], &err)
             } else {
                 print("Cannot generate keys in SEP on macOS<10.12.1")
                 return nil
@@ -231,7 +231,8 @@ class Keychain {
                 (kSecPrivateKeyAttrs, makeCFDictionary(
                     (kSecAttrAccessControl, acl!),
                     (kSecAttrLabel, attrLabel),
-                    (kSecAttrIsPermanent, kCFBooleanTrue)
+                    (kSecAttrIsPermanent, kCFBooleanTrue),
+                    (kSecAttrSynchronizable, kCFBooleanFalse)
                 ))
             )
         } else {

--- a/SoftU2FTool/Keychain.swift
+++ b/SoftU2FTool/Keychain.swift
@@ -151,6 +151,34 @@ class Keychain {
 
         return opaqueResult as! CFData as Data
     }
+    
+    // Lookup all keys with the given label.
+    static func getSecKeys(attrLabel: CFString) -> [SecKey] {
+        let query = makeCFDictionary(
+            (kSecClass, kSecClassKey),
+            (kSecAttrKeyType, kSecAttrKeyTypeEC),
+            (kSecAttrLabel, attrLabel),
+            (kSecReturnRef, kCFBooleanTrue),
+            (kSecMatchLimit, 1000 as CFNumber)
+        )
+        
+        var optionalOpaqueResult: CFTypeRef? = nil
+        let err = SecItemCopyMatching(query, &optionalOpaqueResult)
+        
+        if err != errSecSuccess {
+            print("Error from keychain: \(err)")
+            return []
+        }
+        
+        guard let opaqueResult = optionalOpaqueResult else {
+            print("Unexpected nil returned from keychain")
+            return []
+        }
+        
+        let result = opaqueResult as! [SecKey]
+        
+        return result
+    }
 
     static func getSecKey(attrAppLabel: CFData, keyClass: CFString) -> SecKey? {
         // Lookup public key.

--- a/SoftU2FTool/Keychain.swift
+++ b/SoftU2FTool/Keychain.swift
@@ -170,13 +170,14 @@ class Keychain {
         return result
     }
 
-    static func getPrivateSecKey(attrAppLabel: CFData) -> SecKey? {
+    static func getPrivateSecKey(attrAppLabel: CFData, signPrompt: CFString) -> SecKey? {
         let query = makeCFDictionary(
-                                     (kSecClass, kSecClassKey),
-                                     (kSecAttrKeyType, kSecAttrKeyTypeEC),
-                                     (kSecAttrKeyClass, kSecAttrKeyClassPrivate),
-                                     (kSecAttrApplicationLabel, attrAppLabel),
-                                     (kSecReturnRef, kCFBooleanTrue)
+            (kSecClass, kSecClassKey),
+            (kSecAttrKeyType, kSecAttrKeyTypeEC),
+            (kSecAttrKeyClass, kSecAttrKeyClassPrivate),
+            (kSecAttrApplicationLabel, attrAppLabel),
+            (kSecReturnRef, kCFBooleanTrue),
+            (kSecUseOperationPrompt, signPrompt as CFString)
         )
 
         var optionalOpaqueResult: CFTypeRef? = nil
@@ -332,7 +333,7 @@ class Keychain {
                 return
             }
             
-            guard let _ = getPrivateSecKey(attrAppLabel: attrAppLabel as CFData) else {
+            guard let _ = getPrivateSecKey(attrAppLabel: attrAppLabel as CFData, signPrompt: "" as CFString) else {
                 print("error getting private key for public key")
                 return
             }

--- a/SoftU2FTool/Settings.swift
+++ b/SoftU2FTool/Settings.swift
@@ -9,18 +9,13 @@ import Foundation
 import LocalAuthentication
 
 class Settings {
-    private static let touchidDisabledKey = "touchidDisabled"
     private static let sepEnabledKey = "sepEnabled"
 
-    static var touchidDisabled: Bool {
-        return !touchidAvailable || UserDefaults.standard.bool(forKey: touchidDisabledKey)
-    }
-
     static var sepEnabled: Bool {
-        return touchidAvailable && UserDefaults.standard.bool(forKey: sepEnabledKey)
+        return sepAvailable && UserDefaults.standard.bool(forKey: sepEnabledKey)
     }
 
-    private static var touchidAvailable: Bool {
+    private static var sepAvailable: Bool {
         if #available(OSX 10.12.2, *) {
             return LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
         } else {
@@ -28,21 +23,8 @@ class Settings {
         }
     }
 
-    static func enableTouchid() -> Bool {
-        if touchidAvailable {
-            UserDefaults.standard.set(false, forKey: touchidDisabledKey)
-            return true
-        } else {
-            return false
-        }
-    }
-
-    static func disableTouchid() {
-        UserDefaults.standard.set(true, forKey: touchidDisabledKey)
-    }
-
     static func enableSEP() -> Bool {
-        if touchidAvailable {
+        if sepAvailable {
             UserDefaults.standard.set(true, forKey: sepEnabledKey)
             return true
         } else {

--- a/SoftU2FTool/Settings.swift
+++ b/SoftU2FTool/Settings.swift
@@ -1,0 +1,24 @@
+//
+//  Settings.swift
+//  SoftU2F
+//
+//  Created by Ben Toews on 8/2/17.
+//
+
+import Foundation
+
+class Settings {
+    private static let sepEnabledKey = "sepEnabled"
+
+    static var sepEnabled: Bool {
+        return UserDefaults.standard.bool(forKey: sepEnabledKey)
+    }
+
+    static func enableSEP() {
+        return UserDefaults.standard.set(true, forKey: sepEnabledKey)
+    }
+
+    static func disableSEP() {
+        return UserDefaults.standard.set(false, forKey: sepEnabledKey)
+    }
+}

--- a/SoftU2FTool/Settings.swift
+++ b/SoftU2FTool/Settings.swift
@@ -6,19 +6,33 @@
 //
 
 import Foundation
+import LocalAuthentication
 
 class Settings {
     private static let sepEnabledKey = "sepEnabled"
 
     static var sepEnabled: Bool {
-        return UserDefaults.standard.bool(forKey: sepEnabledKey)
+        return sepAvailable && UserDefaults.standard.bool(forKey: sepEnabledKey)
     }
 
-    static func enableSEP() {
-        return UserDefaults.standard.set(true, forKey: sepEnabledKey)
+    static func enableSEP() -> Bool {
+        if sepAvailable {
+            UserDefaults.standard.set(true, forKey: sepEnabledKey)
+            return true
+        } else {
+            return false
+        }
     }
 
     static func disableSEP() {
-        return UserDefaults.standard.set(false, forKey: sepEnabledKey)
+        UserDefaults.standard.set(false, forKey: sepEnabledKey)
+    }
+
+    private static var sepAvailable: Bool {
+        if #available(OSX 10.12.2, *) {
+            return LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+        } else {
+            return false
+        }
     }
 }

--- a/SoftU2FTool/U2FAuthenticator.swift
+++ b/SoftU2FTool/U2FAuthenticator.swift
@@ -90,9 +90,8 @@ class U2FAuthenticator {
 
         let facet = KnownFacets[req.applicationParameter]
         let notification = UserPresence.Notification.Register(facet: facet)
-        let skipTUP = Settings.sepEnabled
 
-        UserPresence.test(notification, skip: skipTUP) { tupSuccess in
+        UserPresence.test(notification) { tupSuccess in
             if !tupSuccess {
                 // Send no response. Otherwise Chrome will re-prompt immediately.
                 return

--- a/SoftU2FTool/U2FAuthenticator.swift
+++ b/SoftU2FTool/U2FAuthenticator.swift
@@ -14,6 +14,13 @@ class U2FAuthenticator {
     private static var hasShared = false
 
     private let u2fhid: U2FHID
+    
+    var running: Bool
+    
+    static var running: Bool {
+        guard let ua: U2FAuthenticator = shared else { return false }
+        return ua.running
+    }
 
     static func start() -> Bool {
         guard let ua: U2FAuthenticator = shared else { return false }
@@ -28,16 +35,27 @@ class U2FAuthenticator {
     init?() {
         guard let uh: U2FHID = U2FHID.shared else { return nil }
 
+        running = false
         u2fhid = uh
         installMsgHandler()
     }
 
     func start() -> Bool {
-        return u2fhid.run()
+        if u2fhid.run() {
+            running = true
+            return true
+        }
+        
+        return false
     }
 
     func stop() -> Bool {
-        return u2fhid.stop()
+        if u2fhid.stop() {
+            running = false
+            return true
+        }
+        
+        return false
     }
 
     func installMsgHandler() {

--- a/SoftU2FTool/U2FRegistration.swift
+++ b/SoftU2FTool/U2FRegistration.swift
@@ -10,11 +10,11 @@ import Foundation
 class U2FRegistration {
     // Allow using separate keychain namespace for tests.
     static var namespace = "SoftU2F Security Key"
-    
+
     static var all: [U2FRegistration] {
         let kps = KeyPair.all(label: namespace)
         var regs: [U2FRegistration] = []
-        
+
         kps.forEach { kp in
             guard let reg = U2FRegistration(keyPair: kp) else {
                 print("Error initializing U2FRegistration")
@@ -23,7 +23,7 @@ class U2FRegistration {
 
             regs.append(reg)
         }
-        
+
         return regs
     }
 
@@ -31,7 +31,8 @@ class U2FRegistration {
     static var count: Int? {
         return KeyPair.count(label: namespace)
     }
-    
+
+    // Fix up legacy keychain items.
     static func repair() {
         KeyPair.repair(label: namespace)
     }
@@ -49,7 +50,7 @@ class U2FRegistration {
     var keyHandle: Data {
         return padKeyHandle(keyPair.applicationLabel)
     }
-    
+
     var inSEP: Bool {
         return keyPair.inSEP
     }
@@ -96,25 +97,25 @@ class U2FRegistration {
             return nil
         }
     }
-    
+
     // Initialize a registration with all the necessary data.
     init?(keyPair kp: KeyPair) {
         keyPair = kp
-        
+
         // Read our application parameter from the keychain.
         guard let appTag = keyPair.applicationTag else { return nil }
-        
+
         let counterSize = MemoryLayout<UInt32>.size
         let appTagSize = Int(U2F_APPID_SIZE)
-        
+
         if appTag.count != counterSize + appTagSize {
             return nil
         }
-        
+
         counter = appTag.withUnsafeBytes { (ptr:UnsafePointer<UInt32>) -> UInt32 in
             return ptr.pointee.bigEndian
         }
-        
+
         applicationParameter = appTag.subdata(in: counterSize..<(counterSize + appTagSize))
     }
 

--- a/SoftU2FTool/U2FRegistration.swift
+++ b/SoftU2FTool/U2FRegistration.swift
@@ -68,7 +68,11 @@ class U2FRegistration {
     // Find a registration with the given key handle.
     init?(keyHandle kh: Data, applicationParameter ap: Data) {
         let appLabel = unpadKeyHandle(kh)
-        guard let kp = KeyPair(label: U2FRegistration.namespace, appLabel: appLabel) else { return nil }
+
+        let kf = KnownFacets[ap] ?? "site"
+        let prompt = "authenticate with \(kf)"
+
+        guard let kp = KeyPair(label: U2FRegistration.namespace, appLabel: appLabel, signPrompt: prompt) else { return nil }
         keyPair = kp
 
         // Read our application parameter from the keychain and make sure it matches.

--- a/SoftU2FTool/U2FRegistration.swift
+++ b/SoftU2FTool/U2FRegistration.swift
@@ -45,12 +45,16 @@ class U2FRegistration {
     var keyHandle: Data {
         return padKeyHandle(keyPair.applicationLabel)
     }
+    
+    var inSEP: Bool {
+        return keyPair.inSEP
+    }
 
     // Generate a new registration.
-    init?(applicationParameter ap: Data) {
+    init?(applicationParameter ap: Data, inSEP sep: Bool) {
         applicationParameter = ap
 
-        guard let kp = KeyPair(label: U2FRegistration.namespace) else { return nil }
+        guard let kp = KeyPair(label: U2FRegistration.namespace, inSEP: sep) else { return nil }
         keyPair = kp
 
         counter = 1

--- a/SoftU2FTool/U2FRegistration.swift
+++ b/SoftU2FTool/U2FRegistration.swift
@@ -31,6 +31,10 @@ class U2FRegistration {
     static var count: Int? {
         return KeyPair.count(label: namespace)
     }
+    
+    static func repair() {
+        KeyPair.repair(label: namespace)
+    }
 
     // Delete all SoftU2F keys from keychain.
     static func deleteAll() -> Bool {
@@ -122,9 +126,6 @@ class U2FRegistration {
     func incrementCounter() {
         counter += 1
         writeApplicationTag()
-    }
-
-    func readApplicationTag(appTag: Data?) {
     }
 
     // Persist the applicationParameter and counter in the keychain.

--- a/SoftU2FTool/UserPresence.swift
+++ b/SoftU2FTool/UserPresence.swift
@@ -79,40 +79,6 @@ class UserPresence: NSObject {
 
     // Send a notification popup to the user.
     func test(_ type: Notification) {
-        if #available(OSX 10.12.2, *) {
-            if !Settings.touchidDisabled {
-                let ctx = LAContext()
-                
-                if ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
-                    ctx.localizedCancelTitle = "Reject"
-                    ctx.localizedFallbackTitle = "Skip TouchID"
-                    
-                    var prompt: String
-                    switch type {
-                    case let .Register(facet):
-                        prompt = "register with " + (facet ?? "site")
-                    case let .Authenticate(facet):
-                        prompt = "authenticate with " + (facet ?? "site")
-                    }
-                    
-                    ctx.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: prompt) { (success, err) in
-                        guard let lerr = err as? LAError else {
-                            self.complete(success)
-                            return
-                        }
-                        
-                        switch lerr.code {
-                        case .userFallback, .touchIDNotAvailable, .touchIDNotEnrolled:
-                            self.sendNotification(type)
-                        default:
-                            self.complete(false)
-                        }
-                    }
-                    return
-                }
-            }
-        }
-
         sendNotification(type)
     }
 

--- a/SoftU2FTool/UserPresence.swift
+++ b/SoftU2FTool/UserPresence.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import LocalAuthentication
 
 class UserPresence: NSObject {
     enum Notification {

--- a/SoftU2FTool/UserPresence.swift
+++ b/SoftU2FTool/UserPresence.swift
@@ -37,8 +37,8 @@ class UserPresence: NSObject {
 
     // Display a notification, wait for the user to click it, and call the callback with `true`.
     // Calls callback with `false` if another test is done while we're waiting for this one.
-    static func test(_ type: Notification, with callback: @escaping Callback) {
-        if skip {
+    static func test(_ type: Notification, skip skipOnce: Bool = false, with callback: @escaping Callback) {
+        if skip || skipOnce {
             callback(true)
         } else {
             // Fail any outstanding test.

--- a/SoftU2FToolTests/U2FRegistrationTests.swift
+++ b/SoftU2FToolTests/U2FRegistrationTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import SoftU2F
 
 class U2FRegistrationTests: SoftU2FTestCase {
-    var makeKey: U2FRegistration? { return U2FRegistration(applicationParameter: randData(length: 32)) }
+    var makeKey: U2FRegistration? { return U2FRegistration(applicationParameter: randData(length: 32), inSEP: false) }
 
     override func tearDown() {
         let _ = U2FRegistration.deleteAll()


### PR DESCRIPTION
By popular demand, this PR adds the option to store keys in the SEP. This setting can be toggled by invoking the binary with `--[en|dis]able-sep` flags.

For those who are interested in this feature, I'm curious for feedback on the ACL options people would find most useful. The [current setup is](https://github.com/github/SoftU2F/blob/3c29d9b7b229ec01783b7f569fbc22c358fd1e30/SoftU2FTool/Keychain.swift#L218):

```swift
SecAccessControlCreateWithFlags(
  nil, 
  kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
  [.privateKeyUsage, .touchIDCurrentSet],
  &err
)
```

This configuration is quite strict. If you temporarily remove your password or add any new fingerprints to your Touch ID enrollment, all your U2F keys will be deleted. This means that even if someone steals your laptop and gets your password, they still wont be able to access the U2F keys... It also increases risk though of you accidentally deleting your U2F registrations.

You can find docs for `kSecAttrAccessible` values in [`SecItem.h`](https://opensource.apple.com/source/Security/Security-57740.51.3/keychain/SecItem.h.auto.html) and docs for `SecAccessControlCreateFlags` values in [`SecAccessControl.h`](https://opensource.apple.com/source/Security/Security-57740.51.3/OSX/sec/Security/SecAccessControl.h.auto.html).

I don't have one of the new MacBooks handy at the moment, so this code probably doesn't work. I should be able to test this branch out in the next couple weeks though.