### PR TITLE
Ensure LaunchAgents directory exists

### DIFF
--- a/install-scripts/postinstall
+++ b/install-scripts/postinstall
@@ -2,10 +2,15 @@
 set -e
 
 KEXT="/Library/Extensions/softu2f.kext"
-LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/com.github.SoftU2F.plist"
+LAUCNH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+LAUNCH_AGENT_PLIST="$LAUCNH_AGENTS_DIR/com.github.SoftU2F.plist"
 
 # Make sure the kext is loaded
 kextutil $KEXT
+
+# This directory should already exist, but some users have had issues with it
+# being missing.
+mkdir -p $LAUCNH_AGENTS_DIR
 
 # Write a LaunchAgent plist so app starts at login
 cat > $LAUNCH_AGENT_PLIST << EOT


### PR DESCRIPTION
Two users have had issues (#22, #30) where the LaunchAgents directory doesn't exist. I'm not sure what's causing it to be missing, but we might as well ensure its presence in the postinstall script.

/cc @opsroller