### PR TITLE
Ensure kext directory exists

### DIFF
--- a/install-scripts/preinstall
+++ b/install-scripts/preinstall
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-KEXT="/Library/Extensions/softu2f.kext"
+KEXT_DIR="/Library/Extensions"
+KEXT="$KEXT_DIR/softu2f.kext"
 LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/com.github.SoftU2F.plist"
+
+# This directory should already exist, but some users have had issues with it
+# being missing.
+mkdir -p $KEXT_DIR
 
 kextunload $KEXT || true
 sudo -u "${USER}" launchctl unload $LAUNCH_AGENT_PLIST || true


### PR DESCRIPTION
A user reached out, having debugged an install issue to the `/Library/Extensions` directory not existing. This should definitely exist on a fresh install, but we might as well double check during preinstall.

/cc @bluemazzoo 