### PR TITLE
Fix null pointer dereference in driver userclient

### DIFF
--- a/SoftU2F.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SoftU2F.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/script/run
+++ b/script/run
@@ -20,10 +20,10 @@ if kextstat -b $BUNDLE_ID | grep $BUNDLE_ID &> /dev/null; then
 fi
 
 # Ensure kext is owned by root.
-sudo chown -R root:wheel $KEXT_PATH
+sudo chown -R root:wheel "${KEXT_PATH}"
 
 echo "Loading softu2f.kext"
-if ! sudo kextutil $KEXT_PATH; then
+if ! sudo kextutil "${KEXT_PATH}"; then
   echo "Error loading softu2f.kext"
   exit 1
 fi


### PR DESCRIPTION
`IOMemoryDescriptor.map()` will return `NULL` if the report length is 0. This can be triggered by sending a report with a single null byte. This is fixed by checking the memory descriptor length earlier on. To be doubly sure, we also checking the return value from `report->map()`.

cc @herrjemand @philipturnbull 
fixes #48


