### PR TITLE
Add Lastpass to known facets

### DIFF
--- a/SoftU2FTool/KnownFacets.swift
+++ b/SoftU2FTool/KnownFacets.swift
@@ -17,6 +17,7 @@ let KnownFacets: [Data: String] = [
     SHA256.digest("https://api-9dcf9b83.duosecurity.com"): "https://api-9dcf9b83.duosecurity.com",
     SHA256.digest("https://dashboard.stripe.com"): "https://dashboard.stripe.com",
     SHA256.digest("https://id.fedoraproject.org/u2f-origins.json"): "https://id.fedoraproject.org",
+    SHA256.digest("https://lastpass.com"): "https://lastpass.com",
 
     // When we return an error during authentication, Chrome will send a registration request with
     // a bogus AppID.


### PR DESCRIPTION
Adding http://lastpass.com to the list of know facets. Premium users are able to use yubico devices for 2FA.